### PR TITLE
bot will no longer send a message to the chat if it cannot resolve a query

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -159,9 +159,6 @@ var getUserMessages = function(user, channelId){
             var responseData = JSON.parse(body);
             if(!responseData.messages || responseData.messages.total < 1){
                 console.log('no messages found for that user');
-                rtm.sendMessage("No messages found for: "+user, channelId, function(err, msg){
-
-                });
                 return;
             }
             var messages = [];


### PR DESCRIPTION
if a query fails, no slack output and console logging should be good enough, otherwise the slack channel gets filled with error messages for missing user queries.
