### PR TITLE
Removing leading @mention in the bot response

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -113,7 +113,7 @@ var markovChain = function(messages, user, channelId){
     }
 
     console.log(str);
-    rtm.sendMessage("@"+user + ": \""+str+"\"", channelId, function(err, msg){
+    rtm.sendMessage("\""+str+"\"", channelId, function(err, msg){
 
     });
 }


### PR DESCRIPTION
....because it is redundant data. We already know who is being Markov'd, the bot reminding us is unnecessary wasted space. 
